### PR TITLE
Fix typo and add BackgroundColor to IConsole

### DIFF
--- a/Tharga.Toolkit.Console/Command/Base/CommandBase.cs
+++ b/Tharga.Toolkit.Console/Command/Base/CommandBase.cs
@@ -38,7 +38,7 @@ namespace Tharga.Toolkit.Console.Command.Base
         protected abstract CommandBase GetHelpCommand();
         public abstract bool CanExecute();
 
-        protected virtual string GetCanExecuteFaileMessage()
+        protected virtual string GetCanExecuteFailMessage()
         {
             return string.Format("You cannot execute this {0} command.", Name);
         }
@@ -47,7 +47,7 @@ namespace Tharga.Toolkit.Console.Command.Base
         {
             if (!CanExecute())
             {
-                OutputWarning(GetCanExecuteFaileMessage());
+                OutputWarning(GetCanExecuteFailMessage());
                 return true;
             }
 

--- a/Tharga.Toolkit.Console/Command/Base/IConsole.cs
+++ b/Tharga.Toolkit.Console/Command/Base/IConsole.cs
@@ -11,6 +11,7 @@ namespace Tharga.Toolkit.Console.Command.Base
         int BufferWidth { get; set; }
         int CursorTop { get; set; }
         ConsoleColor ForegroundColor { get; set; }
+        ConsoleColor BackgroundColor { get; set; }
         string ReadLine();
         ConsoleKeyInfo ReadKey();
         void NewLine();

--- a/Tharga.Toolkit.Console/Command/Base/SystemConsoleBase.cs
+++ b/Tharga.Toolkit.Console/Command/Base/SystemConsoleBase.cs
@@ -33,6 +33,12 @@ namespace Tharga.Toolkit.Console.Command.Base
             set { System.Console.ForegroundColor = value; }
         }
 
+        public ConsoleColor BackgroundColor
+        {
+            get { return System.Console.BackgroundColor; }
+            set { System.Console.BackgroundColor = value; }
+        }
+
         public virtual string ReadLine() { return System.Console.ReadLine(); }
         public virtual ConsoleKeyInfo ReadKey() { return System.Console.ReadKey(); }
         public void NewLine() { System.Console.WriteLine(); }


### PR DESCRIPTION
The addition of `BackgroundColor` makes any IConsole a drop-in replacement for `System.Console` for most tasks.