### PR TITLE
execute command specified in command line arguments

### DIFF
--- a/Tharga.Toolkit.Console.Tests/CommandEngineTests.cs
+++ b/Tharga.Toolkit.Console.Tests/CommandEngineTests.cs
@@ -25,6 +25,22 @@ namespace Tharga.Toolkit.Console.Tests
         }
 
         [Test]
+        public void When_typing_the_exit_command_the_command_engine_should_exit()
+        {
+            //Arrange
+            var input = new[] { ConsoleKey.E, ConsoleKey.X, ConsoleKey.I, ConsoleKey.T, ConsoleKey.Enter };
+            var consoleManager = new FakeConsoleManager(new FakeKeyInputEngine(input));
+            var console = new TestConsole(consoleManager);
+            var command = new RootCommand(console);
+
+            //Act
+            new CommandEngine(command).Start(new string[] { });
+
+            //Assert
+            Assert.True(true);
+        }
+
+        [Test]
         public void When_registering_two_commands_with_the_same_name()
         {
             //Arrange

--- a/Tharga.Toolkit.Console.Tests/Tharga.Toolkit.Console.Tests.csproj
+++ b/Tharga.Toolkit.Console.Tests/Tharga.Toolkit.Console.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Table_Formatter_tests.cs" />
     <Compile Include="Tab_command_recall_tests.cs" />
     <Compile Include="TestConsole.cs" />
+    <Compile Include="With_command_line.cs" />
     <Compile Include="When_running_engine.cs" />
     <Compile Include="When_running_engine_outside_the_buffer_height.cs" />
     <Compile Include="When_running_in_parallel.cs" />

--- a/Tharga.Toolkit.Console.Tests/With_command_line.cs
+++ b/Tharga.Toolkit.Console.Tests/With_command_line.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using Tharga.Toolkit.Console.Commands;
+using Tharga.Toolkit.Console.Commands.Base;
+using Tharga.Toolkit.Console.Consoles;
+using Tharga.Toolkit.Console.Entities;
+using Tharga.Toolkit.Console.Helpers;
+using Tharga.Toolkit.Console.Interfaces;
+
+namespace Tharga.Toolkit.Console.Tests
+{
+
+    class TestAction : ActionCommandBase
+    {
+        internal bool WasRun = false;
+        string[] Params = null;
+        public TestAction(string name) : base(name) { }
+
+        public override void Invoke(string[] param)
+        {
+            WasRun = true;
+            Params = param;
+        }
+    }
+
+    class TestContainerCommand : ContainerCommandBase
+    {
+        internal TestAction inner = new TestAction("Inner");
+        public TestContainerCommand() : base("Outer")
+        {
+            RegisterCommand(this.inner);
+        }
+    }
+
+    [TestFixture]
+    public class With_command_line
+    {
+        private TestAction simple;
+        private TestContainerCommand containerCommand;
+        private CommandEngine commandEngine;
+        private RootCommand command;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.simple = new TestAction("Simple");
+            this.containerCommand = new TestContainerCommand();
+            this.command = new RootCommand(new TestConsole(new FakeConsoleManager()));
+            this.commandEngine = new CommandEngine(this.command);
+            command.RegisterCommand(this.simple);
+            command.RegisterCommand(this.containerCommand);
+        }
+
+        [Test]
+        public void With_no_args()
+        {
+            Task.Run(() => { commandEngine.Start(new string[] { }); }).Wait(100);
+
+            Assert.False(simple.WasRun);
+            Assert.False(containerCommand.inner.WasRun);
+        }
+
+        [Test]
+        public void With_top_level_command()
+        {
+            var args = new string[] { "Simple" };
+            commandEngine.Start(args);
+
+            Assert.True(simple.WasRun, "EXPECTED SIMPLE TO BE RUN");
+            Assert.False(containerCommand.inner.WasRun, "EXPECTED INNER NOT TO BE RUN");
+        }
+
+        [Test]
+        public void With_subcommand()
+        {
+            var args = new string[] { "Outer Inner" };
+            commandEngine.Start(args);
+
+            Assert.False(simple.WasRun);
+            Assert.True(containerCommand.inner.WasRun);
+        }
+    }
+}

--- a/Tharga.Toolkit.Console/CommandEngine.cs
+++ b/Tharga.Toolkit.Console/CommandEngine.cs
@@ -100,18 +100,15 @@ namespace Tharga.Toolkit.Console
                         }
                     }
 
-                    if (!_cancellationTokenSource.IsCancellationRequested)
+                    if (!Execute(entry))
                     {
-                        if (!Execute(entry))
+                        if (_commandMode && HasFlag(args, FlagContinueInConsoleModeIfError))
                         {
-                            if (_commandMode && HasFlag(args, FlagContinueInConsoleModeIfError))
-                            {
-                                _commandMode = false;
-                                continue;
-                            }
-
-                            break;
+                            _commandMode = false;
+                            continue;
                         }
+
+                        break;
                     }
                 }
 


### PR DESCRIPTION
Commands specified as command line arguments do not actually appear to be run.  When parsing the command, cancellation is set and then checked prior to execution.  Simply commenting the inner condition check seems to allow the command-line command to execute, while preserving behavior of exit.  I don't know if there are other scenarios in which a command must cause exit _before_ actually running.