### PR TITLE
ci: pack and publish Tharga.Console.Standard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Pack
         run: |
           dotnet pack Tharga.Console/Tharga.Console.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          dotnet pack Tharga.Console.Standard/Tharga.Console.Standard.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
           dotnet pack Tharga.Console.Speech/Tharga.Console.Speech.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
 
       - name: Upload artifacts


### PR DESCRIPTION
## Summary
- Adds `Tharga.Console.Standard` to the workflow's Pack step so all three NuGet packages ship together — previously only `Tharga.Console` and `Tharga.Console.Speech` were packed.
- The existing release/prerelease loop (`for pkg in ./artifacts/*.nupkg`) automatically picks up the new package.

## Test plan
- [ ] PR build runs the prerelease job and produces three `.nupkg` files in artifacts
- [ ] Once merged, the release job pushes all three packages to nuget.org under the same `${MAJOR_MINOR}.{PATCH}` version