### PR TITLE
Update NuGet packages

### DIFF
--- a/SampleCoreConsole/SampleCoreConsole.csproj
+++ b/SampleCoreConsole/SampleCoreConsole.csproj
@@ -7,7 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Castle.Windsor" Version="6.0.0" />
-		<PackageReference Include="System.Text.Json" Version="10.0.7" />
+		<PackageReference Include="System.Text.Json" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Console.Speech/Tharga.Console.Speech.csproj
+++ b/Tharga.Console.Speech/Tharga.Console.Speech.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="System.Speech" Version="10.0.7" />
+	  <PackageReference Include="System.Speech" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Console.Tests/Tharga.Console.Tests.csproj
+++ b/Tharga.Console.Tests/Tharga.Console.Tests.csproj
@@ -5,7 +5,7 @@
 		<NoWarn>xUnit1031;xUnit1051</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="8.9.0" />
+		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Tharga.Console/Tharga.Console.csproj
+++ b/Tharga.Console/Tharga.Console.csproj
@@ -31,8 +31,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-	  <PackageReference Include="Tharga.Runtime" Version="0.1.11" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+	  <PackageReference Include="Tharga.Runtime" Version="0.1.12" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Routine dependency bumps (`be13d7d`):

- `System.Text.Json` 10.0.7 → 10.0.8 (SampleCoreConsole)
- `System.Speech` 10.0.7 → 10.0.8 (Tharga.Console.Speech)
- `Microsoft.Extensions.Logging` 10.0.7 → 10.0.8 (Tharga.Console)
- `Tharga.Runtime` 0.1.11 → 0.1.12 (Tharga.Console)
- `FluentAssertions` 8.9.0 → 8.10.0 (Tharga.Console.Tests)

## Test plan

- [x] `dotnet build -c Release` clean
- [x] `dotnet test -c Release` — 44 pass / 0 fail / 2 pre-existing skips