### PR TITLE
feat!: drop net8.0/net9.0 and bump dependencies (→ 4.2.0)

### DIFF
--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -3,5 +3,5 @@
 ## External References
 - **Shared instructions**: `$DOC_ROOT/Tharga/shared-instructions.md`
 - **Plan directory**: `$DOC_ROOT/Tharga/plans/Toolkit/Console`
-- **Backlog**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Toolkit\Console.md`
+- **Backlog**: `$DOC_ROOT/Tharga/Toolkit/Console.md`
 - **Incoming requests**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Requests.md` — check for pending requests for this project on startup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,41 +28,17 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build -c Release --no-restore 2>&1 | tee build.log
-
-      - name: Check warnings
-        run: |
-          WARNING_COUNT=$(grep -c " warning " build.log || true)
-          echo "Build warnings: $WARNING_COUNT"
-          if [ "$WARNING_COUNT" -gt 15 ]; then
-            echo "::error::Build has $WARNING_COUNT warnings (threshold: 15)"
-            exit 1
-          fi
-
-      - name: Test
-        run: dotnet test -c Release --no-build --verbosity normal --filter "Category!=Database" --blame-hang-timeout 90s --blame-hang-dump-type none
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          directory: ./coverage
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
+      # Version is computed BEFORE the build so it can be passed as -p:Version.
+      # Passing it only to `dotnet pack` sets PackageVersion alone, leaving
+      # AssemblyVersion and FileVersion at their default 1.0.0.0 inside the
+      # shipped assembly.
       - name: Compute version
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -97,11 +73,52 @@ jobs:
           echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed pre-release version: $PRE_VERSION"
 
-      - name: Pack
+      # Pull requests build the pre-release version, pushes to master the
+      # stable one. One value drives build and pack so the assembly and the
+      # package can never disagree.
+      - name: Resolve build version
+        id: buildversion
+        shell: bash
         run: |
-          dotnet pack Tharga.Console/Tharga.Console.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Console.Standard/Tharga.Console.Standard.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
-          dotnet pack Tharga.Console.Speech/Tharga.Console.Speech.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            VERSION="${{ steps.preversion.outputs.version }}"
+          else
+            VERSION="${{ steps.version.outputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building as: $VERSION"
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore -p:Version=${{ steps.buildversion.outputs.version }} 2>&1 | tee build.log
+
+      - name: Check warnings
+        run: |
+          WARNING_COUNT=$(grep -c " warning " build.log || true)
+          echo "Build warnings: $WARNING_COUNT"
+          if [ "$WARNING_COUNT" -gt 15 ]; then
+            echo "::error::Build has $WARNING_COUNT warnings (threshold: 15)"
+            exit 1
+          fi
+
+      - name: Test
+        run: dotnet test -c Release --no-build --verbosity normal --filter "Category!=Database" --blame-hang-timeout 90s --blame-hang-dump-type none
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Pack
+        shell: bash
+        run: |
+          dotnet pack Tharga.Console/Tharga.Console.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
+          dotnet pack Tharga.Console.Standard/Tharga.Console.Standard.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
+          dotnet pack Tharga.Console.Speech/Tharga.Console.Speech.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -123,10 +140,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
       - name: Build for CodeQL
         run: dotnet build -c Release
@@ -160,7 +174,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -234,7 +248,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -285,10 +299,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
       - name: Install DocFX
         run: dotnet tool install -g docfx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '4.1'
+  MAJOR_MINOR: '4.2'
 
 permissions:
   contents: write

--- a/SampleConsole/SampleConsole.csproj
+++ b/SampleConsole/SampleConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/SampleCoreConsole/SampleCoreConsole.csproj
+++ b/SampleCoreConsole/SampleCoreConsole.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/SampleCoreConsole/SampleCoreConsole.csproj
+++ b/SampleCoreConsole/SampleCoreConsole.csproj
@@ -7,7 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Castle.Windsor" Version="6.0.0" />
-		<PackageReference Include="System.Text.Json" Version="10.0.8" />
+		<PackageReference Include="System.Text.Json" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Console.Speech/Tharga.Console.Speech.csproj
+++ b/Tharga.Console.Speech/Tharga.Console.Speech.csproj
@@ -16,7 +16,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<NoWarn>1701;1702;CS1591;CA1416</NoWarn>
+		<!--
+			NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+			Suppressed deliberately. Tharga packages reference their icon from
+			https://thargelion.net/assets/ so all package icons are maintained in one
+			place and can be updated without republishing a package.
+		-->
+		<NoWarn>1701;1702;CS1591;CA1416;NU5048</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tharga.Console.Speech/Tharga.Console.Speech.csproj
+++ b/Tharga.Console.Speech/Tharga.Console.Speech.csproj
@@ -8,7 +8,7 @@
 		<Product>Tharga Console Speech</Product>
 		<PackageTags>console poc posh powershell speech</PackageTags>
 		<PackageIconUrl>https://thargelion.net/assets/component-console.png</PackageIconUrl>
-		<RepositoryUrl>https://github.com/poxet/tharga-console.git</RepositoryUrl>
+		<RepositoryUrl>https://github.com/Tharga/Console</RepositoryUrl>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageProjectUrl>https://github.com/Tharga/Console</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Tharga.Console.Speech/Tharga.Console.Speech.csproj
+++ b/Tharga.Console.Speech/Tharga.Console.Speech.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<RootNamespace>Tharga.Console</RootNamespace>
 		<Version>1.0.0</Version>
 		<Authors>Daniel Bohlin</Authors>

--- a/Tharga.Console.Speech/Tharga.Console.Speech.csproj
+++ b/Tharga.Console.Speech/Tharga.Console.Speech.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<TargetFrameworks>net10.0</TargetFrameworks>
 		<RootNamespace>Tharga.Console</RootNamespace>
-		<Version>1.0.0</Version>
 		<Authors>Daniel Bohlin</Authors>
 		<Company>Thargelion AB</Company>
 		<Product>Tharga Console Speech</Product>

--- a/Tharga.Console.Speech/Tharga.Console.Speech.csproj
+++ b/Tharga.Console.Speech/Tharga.Console.Speech.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="System.Speech" Version="10.0.8" />
+	  <PackageReference Include="System.Speech" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Console.Standard/Commands/Base/ActionCommandBase.cs
+++ b/Tharga.Console.Standard/Commands/Base/ActionCommandBase.cs
@@ -112,6 +112,10 @@ namespace Tharga.Console.Commands.Base
                 var entitySource = pair[1];
 
                 var property = entity.GetType().GetProperty(entitySource);
+                // GetProperty returns null for an unknown name, which used to
+                // surface as a bare NullReferenceException on the next line.
+                if (property == null) throw new InvalidOperationException($"Type '{entity.GetType().Name}' has no property named '{entitySource}'.");
+
                 var val = property.GetValue(entity);
 
                 VariableStore.Instance.Add(new Variable(pair[0], val));

--- a/Tharga.Console.Standard/Consoles/ActionConsole.cs
+++ b/Tharga.Console.Standard/Consoles/ActionConsole.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using Tharga.Console.Consoles.Base;
@@ -68,16 +68,6 @@ namespace Tharga.Console.Consoles
         protected override void OnKeyReadEvent(KeyReadEventArgs e)
         {
             base.OnKeyReadEvent(e);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return base.Equals(obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
         }
 
         internal override void OnLineWrittenEvent(LineWrittenEventArgs e)

--- a/Tharga.Console.Standard/Consoles/Base/ConsoleBase.cs
+++ b/Tharga.Console.Standard/Consoles/Base/ConsoleBase.cs
@@ -431,10 +431,9 @@ namespace Tharga.Console.Consoles.Base
 
         private void SetLocation(string tag, Location location)
         {
-            if (_tagLocalLocation.ContainsKey(tag))
-                _tagLocalLocation[tag] = location;
-            else
-                _tagLocalLocation.Add(tag, location);
+            // The indexer already adds when the key is absent and replaces when
+            // it is present, so the ContainsKey probe was a redundant lookup.
+            _tagLocalLocation[tag] = location;
         }
 
         public void OutputError(Exception exception, bool includeStackTrace = false, string prefix = null)

--- a/Tharga.Console.Standard/Consoles/EventConsole.cs
+++ b/Tharga.Console.Standard/Consoles/EventConsole.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using Tharga.Console.Consoles.Base;
@@ -61,16 +61,6 @@ namespace Tharga.Console.Consoles
         protected override void OnKeyReadEvent(KeyReadEventArgs e)
         {
             base.OnKeyReadEvent(e);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return base.Equals(obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
         }
 
         internal override void OnLineWrittenEvent(LineWrittenEventArgs e)

--- a/Tharga.Console.Standard/Consoles/NullConsole.cs
+++ b/Tharga.Console.Standard/Consoles/NullConsole.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using Tharga.Console.Consoles.Base;
@@ -58,16 +58,6 @@ namespace Tharga.Console.Consoles
         public override string ToString()
         {
             return base.ToString();
-        }
-
-        public override bool Equals(object obj)
-        {
-            return base.Equals(obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
         }
     }
 }

--- a/Tharga.Console.Standard/Extensions/IntExtensions.cs
+++ b/Tharga.Console.Standard/Extensions/IntExtensions.cs
@@ -8,9 +8,23 @@ namespace Tharga.Console
     {
         public static int Max<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector, int defaultValue)
         {
-            if (!source.Any()) return defaultValue;
-            var val = source.Max(selector);
-            return val;
+            // Previously called Any() and then Max(), enumerating the source
+            // twice. That is wrong for a lazy or single-pass sequence, so walk
+            // it once instead.
+            var found = false;
+            var max = defaultValue;
+
+            foreach (var item in source)
+            {
+                var value = selector(item);
+                if (!found || value > max)
+                {
+                    max = value;
+                    found = true;
+                }
+            }
+
+            return found ? max : defaultValue;
         }
 
         public static int Max(this int value, int other)

--- a/Tharga.Console.Standard/Helpers/TextWriterInterceptor.cs
+++ b/Tharga.Console.Standard/Helpers/TextWriterInterceptor.cs
@@ -9,10 +9,13 @@ namespace Tharga.Console.Helpers
 {
     internal class TextWriterInterceptor : TextWriter
     {
-        public new static readonly TextWriter Null;
+        // `Null` and `CoreNewLine` used to be redeclared here with `new`, hiding
+        // the TextWriter members of the same name. Neither was ever assigned, so
+        // TextWriterInterceptor.Null was always null instead of TextWriter.Null,
+        // and the shadowed CoreNewLine was dead. Nothing referenced either, so
+        // they are gone and the inherited members apply.
         private readonly IConsole _console;
         private readonly IConsoleManager _consoleWriter;
-        protected new char[] CoreNewLine;
 
         private const bool _writeLineFeed = false; //TODO: When performing writel, a temporary buffer location should be stored so that next write will continue where the previous one left off.
 

--- a/Tharga.Console.Standard/Helpers/VariableStore.cs
+++ b/Tharga.Console.Standard/Helpers/VariableStore.cs
@@ -25,6 +25,10 @@ namespace Tharga.Console.Helpers
         public T Get<T>(string value)
         {
             var var = _variables.SingleOrDefault(x => string.Compare(x.Name, value, StringComparison.InvariantCultureIgnoreCase) == 0);
+            // Variable is a class, so an unknown name yielded null here and the
+            // next line threw a bare NullReferenceException naming nothing.
+            if (var == null) throw new InvalidOperationException($"There is no variable named '{value}'.");
+
             var stringVar = var.Value.ToString();
             return (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFromInvariantString(stringVar);
         }

--- a/Tharga.Console.Standard/Tharga.Console.Standard.csproj
+++ b/Tharga.Console.Standard/Tharga.Console.Standard.csproj
@@ -8,7 +8,7 @@
 		<Product>Tharga Console Standard</Product>
 		<PackageTags>console poc posh powershell</PackageTags>
 		<PackageIconUrl>https://thargelion.net/assets/component-console.png</PackageIconUrl>
-		<RepositoryUrl>https://github.com/poxet/tharga-console.git</RepositoryUrl>
+		<RepositoryUrl>https://github.com/Tharga/Console</RepositoryUrl>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageProjectUrl>https://github.com/Tharga/Console</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Tharga.Console.Standard/Tharga.Console.Standard.csproj
+++ b/Tharga.Console.Standard/Tharga.Console.Standard.csproj
@@ -16,7 +16,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<NoWarn>1701;1702;CS1591</NoWarn>
+		<!--
+			NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+			Suppressed deliberately. Tharga packages reference their icon from
+			https://thargelion.net/assets/ so all package icons are maintained in one
+			place and can be updated without republishing a package.
+		-->
+		<NoWarn>1701;1702;CS1591;NU5048</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tharga.Console.Standard/Tharga.Console.Standard.csproj
+++ b/Tharga.Console.Standard/Tharga.Console.Standard.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<RootNamespace>Tharga.Console</RootNamespace>
-		<Version>1.0.0</Version>
 		<Authors>Daniel Bohlin</Authors>
 		<Company>Thargelion AB</Company>
 		<Product>Tharga Console Standard</Product>

--- a/Tharga.Console.sln
+++ b/Tharga.Console.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{131058FA-7B3E-4359-8A5B-D9BD80D161F6}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\build.yml = .github\workflows\build.yml
+		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Tharga.Console/Tharga.Console.csproj
+++ b/Tharga.Console/Tharga.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<Version>1.0.0</Version>
 		<Authors>Daniel Bohlin</Authors>
 		<Company>Thargelion AB</Company>

--- a/Tharga.Console/Tharga.Console.csproj
+++ b/Tharga.Console/Tharga.Console.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net10.0</TargetFrameworks>
-		<Version>1.0.0</Version>
 		<Authors>Daniel Bohlin</Authors>
 		<Company>Thargelion AB</Company>
 		<Product>Tharga Console</Product>

--- a/Tharga.Console/Tharga.Console.csproj
+++ b/Tharga.Console/Tharga.Console.csproj
@@ -7,7 +7,7 @@
 		<Product>Tharga Console</Product>
 		<PackageTags>console poc posh powershell</PackageTags>
 		<PackageIconUrl>https://thargelion.net/assets/component-console.png</PackageIconUrl>
-		<RepositoryUrl>https://github.com/poxet/tharga-console.git</RepositoryUrl>
+		<RepositoryUrl>https://github.com/Tharga/Console</RepositoryUrl>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageProjectUrl>https://github.com/Tharga/Console</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Tharga.Console/Tharga.Console.csproj
+++ b/Tharga.Console/Tharga.Console.csproj
@@ -31,8 +31,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-	  <PackageReference Include="Tharga.Runtime" Version="0.1.14" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+	  <PackageReference Include="Tharga.Runtime" Version="0.1.15" />
 	</ItemGroup>
 
 </Project>

--- a/Tharga.Console/Tharga.Console.csproj
+++ b/Tharga.Console/Tharga.Console.csproj
@@ -15,7 +15,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<NoWarn>1701;1702;CS1591</NoWarn>
+		<!--
+			NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+			Suppressed deliberately. Tharga packages reference their icon from
+			https://thargelion.net/assets/ so all package icons are maintained in one
+			place and can be updated without republishing a package.
+		-->
+		<NoWarn>1701;1702;CS1591;NU5048</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -31,7 +37,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-	  <PackageReference Include="Tharga.Runtime" Version="0.1.15" />
+	  <PackageReference Include="Tharga.Runtime" Version="1.0.0" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Patch-level external bumps plus internal `Tharga.*` bumps to consume the tier-0 releases.

External (patch):
- Microsoft.Extensions.Logging 10.0.8 -> 10.0.10
- System.Speech 10.0.8 -> 10.0.10
- System.Text.Json 10.0.8 -> 10.0.10 (sample)

Internal:
- Tharga.Runtime 0.1.14 -> 0.1.15

Verified locally: `dotnet test -c Release` passes.