### PR TITLE
chore: declare licence, publish symbols, and clear redundant code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+root = true
+
+[*.cs]
+
+# Private static readonly fields hold values that are conceptually constants but
+# cannot be declared `const` (TimeSpan, arrays, …). They are named in PascalCase
+# so they read alongside the real `const` members rather than looking like
+# mutable instance state.
+dotnet_naming_rule.static_readonly_fields_are_pascal_case.severity = suggestion
+dotnet_naming_rule.static_readonly_fields_are_pascal_case.symbols = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_are_pascal_case.style = pascal_case
+
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = *
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = static,readonly
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+# Test classes are named as sentences on purpose — `With_command_line`,
+# `When_writing_a_line`, `When_running_in_parallel` — because the class name is
+# the "given" half of the test description and reads directly in the runner
+# output. Their fields follow the same relaxed style. ReSharper's default rules
+# want PascalCase types and _camelCase fields, which would destroy that.
+[**/*.Tests/**.cs]
+resharper_inconsistent_naming_highlighting = none
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,9 +190,15 @@ jobs:
 
       - name: Push to NuGet
         run: |
+          # Only *.nupkg is globbed. Each matching package's sibling .snupkg is
+          # uploaded automatically by dotnet nuget push, so symbols must NOT be
+          # pushed explicitly or nuget.org sees a duplicate.
+          ls -l ./artifacts/
           for pkg in ./artifacts/*.nupkg; do
             echo "Pushing $pkg..."
-            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+            # --skip-duplicate already makes a re-run of an existing version a
+            # success, so a failure here is a real failure and must fail the job.
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
       - name: Create GitHub Release
@@ -273,9 +279,15 @@ jobs:
 
       - name: Push to NuGet
         run: |
+          # Only *.nupkg is globbed. Each matching package's sibling .snupkg is
+          # uploaded automatically by dotnet nuget push, so symbols must NOT be
+          # pushed explicitly or nuget.org sees a duplicate.
+          ls -l ./artifacts/
           for pkg in ./artifacts/*.nupkg; do
             echo "Pushing $pkg..."
-            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+            # --skip-duplicate already makes a re-run of an existing version a
+            # success, so a failure here is a real failure and must fail the job.
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
       - name: Create GitHub Pre-release

--- a/SampleCoreConsole/Program.cs
+++ b/SampleCoreConsole/Program.cs
@@ -13,7 +13,6 @@ using Tharga.Console;
 using Tharga.Console.Commands;
 using Tharga.Console.Commands.Base;
 using Tharga.Console.Entities;
-using Tharga.Console.Helpers;
 using Tharga.Console.Interfaces;
 using Timer = System.Timers.Timer;
 

--- a/SampleCoreConsole/SampleCoreConsole.csproj
+++ b/SampleCoreConsole/SampleCoreConsole.csproj
@@ -7,7 +7,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Castle.Windsor" Version="6.0.0" />
-		<PackageReference Include="System.Text.Json" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Console.Speech/Tharga.Console.Speech.csproj
+++ b/Tharga.Console.Speech/Tharga.Console.Speech.csproj
@@ -13,6 +13,16 @@
 		<PackageProjectUrl>https://github.com/Tharga/Console</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<DebugType>portable</DebugType>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSource>true</IncludeSource>
+		<IncludeSymbols>true</IncludeSymbols>
+		<!-- snupkg, not the legacy .symbols.nupkg: that name still ends in .nupkg,
+		     so the release push loop would upload it as a regular package and
+		     nuget.org would reject it as a duplicate. -->
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Tharga.Console.Standard/Consoles/ActionConsole.cs
+++ b/Tharga.Console.Standard/Consoles/ActionConsole.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Threading;
 using Tharga.Console.Consoles.Base;
 using Tharga.Console.Entities;
 using Tharga.Console.Helpers;
@@ -24,55 +22,15 @@ namespace Tharga.Console.Consoles
             _action(new ActionConsoleOutput(output.Message, output.OutputLevel));
         }
 
-        public override void Attach(IRootCommand command)
-        {
-            base.Attach(command);
-        }
-
-        public override void Initiate(IEnumerable<string> commandKeys)
-        {
-            base.Initiate(commandKeys);
-        }
-
-        public override string ToString()
-        {
-            return base.ToString();
-        }
-
         //public override ConsoleKeyInfo ReadKey()
         //{
         //    return base.ReadKey();
         //}
 
-        public override ConsoleKeyInfo ReadKey(CancellationToken cancellationToken)
-        {
-            return base.ReadKey(cancellationToken);
-        }
-
-        protected override void OnLinesInsertedEvent(int lineCount)
-        {
-            base.OnLinesInsertedEvent(lineCount);
-        }
-
         protected internal override Location WriteLineEx(string value, OutputLevel level)
         {
             _action(new ActionConsoleOutput(value, level));
             return new Location(0, 0);
-        }
-
-        protected override void OnPushBufferDownEvent(int lineCount)
-        {
-            base.OnPushBufferDownEvent(lineCount);
-        }
-
-        protected override void OnKeyReadEvent(KeyReadEventArgs e)
-        {
-            base.OnKeyReadEvent(e);
-        }
-
-        internal override void OnLineWrittenEvent(LineWrittenEventArgs e)
-        {
-            base.OnLineWrittenEvent(e);
         }
     }
 }

--- a/Tharga.Console.Standard/Consoles/EventConsole.cs
+++ b/Tharga.Console.Standard/Consoles/EventConsole.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Threading;
 using Tharga.Console.Consoles.Base;
 using Tharga.Console.Entities;
 using Tharga.Console.Helpers;
@@ -22,50 +20,10 @@ namespace Tharga.Console.Consoles
             OutputEv?.Invoke(this,new OutputEventArgs(output.Message, output.OutputLevel));
         }
 
-        public override void Attach(IRootCommand command)
-        {
-            base.Attach(command);
-        }
-
-        public override void Initiate(IEnumerable<string> commandKeys)
-        {
-            base.Initiate(commandKeys);
-        }
-
-        public override string ToString()
-        {
-            return base.ToString();
-        }
-
-        public override ConsoleKeyInfo ReadKey(CancellationToken cancellationToken)
-        {
-            return base.ReadKey(cancellationToken);
-        }
-
-        protected override void OnLinesInsertedEvent(int lineCount)
-        {
-            base.OnLinesInsertedEvent(lineCount);
-        }
-
         protected internal override Location WriteLineEx(string value, OutputLevel level)
         {
             OutputEv?.Invoke(this, new OutputEventArgs(value, level));
             return new Location(0, 0);
-        }
-
-        protected override void OnPushBufferDownEvent(int lineCount)
-        {
-            base.OnPushBufferDownEvent(lineCount);
-        }
-
-        protected override void OnKeyReadEvent(KeyReadEventArgs e)
-        {
-            base.OnKeyReadEvent(e);
-        }
-
-        internal override void OnLineWrittenEvent(LineWrittenEventArgs e)
-        {
-            base.OnLineWrittenEvent(e);
         }
     }
 }

--- a/Tharga.Console.Standard/Consoles/NullConsole.cs
+++ b/Tharga.Console.Standard/Consoles/NullConsole.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading;
-using Tharga.Console.Consoles.Base;
+﻿using Tharga.Console.Consoles.Base;
 using Tharga.Console.Entities;
 using Tharga.Console.Helpers;
 using Tharga.Console.Interfaces;
@@ -28,16 +25,6 @@ namespace Tharga.Console.Consoles
         {
         }
 
-        public override void Attach(IRootCommand command)
-        {
-            base.Attach(command);
-        }
-
-        public override void Initiate(IEnumerable<string> commandKeys)
-        {
-            base.Initiate(commandKeys);
-        }
-
         protected override void OnKeyReadEvent(KeyReadEventArgs e)
         {
         }
@@ -48,16 +35,6 @@ namespace Tharga.Console.Consoles
 
         protected override void OnPushBufferDownEvent(int lineCount)
         {
-        }
-
-        public override ConsoleKeyInfo ReadKey(CancellationToken cancellationToken)
-        {
-            return base.ReadKey(cancellationToken);
-        }
-
-        public override string ToString()
-        {
-            return base.ToString();
         }
     }
 }

--- a/Tharga.Console.Standard/Entities/InputBufferChangedEventArgs.cs
+++ b/Tharga.Console.Standard/Entities/InputBufferChangedEventArgs.cs
@@ -1,11 +1,8 @@
-using System;
+﻿using System;
 
 namespace Tharga.Console.Entities
 {
     internal class InputBufferChangedEventArgs : EventArgs
     {
-        public InputBufferChangedEventArgs()
-        {
-        }
     }
 }

--- a/Tharga.Console.Standard/Extensions/IntExtensions.cs
+++ b/Tharga.Console.Standard/Extensions/IntExtensions.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Tharga.Console
 {

--- a/Tharga.Console.Standard/Tharga.Console.Standard.csproj
+++ b/Tharga.Console.Standard/Tharga.Console.Standard.csproj
@@ -13,6 +13,16 @@
 		<PackageProjectUrl>https://github.com/Tharga/Console</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<DebugType>portable</DebugType>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSource>true</IncludeSource>
+		<IncludeSymbols>true</IncludeSymbols>
+		<!-- snupkg, not the legacy .symbols.nupkg: that name still ends in .nupkg,
+		     so the release push loop would upload it as a regular package and
+		     nuget.org would reject it as a duplicate. -->
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Tharga.Console.Tests/CommandEngineTests.cs
+++ b/Tharga.Console.Tests/CommandEngineTests.cs
@@ -2,7 +2,6 @@
 using FluentAssertions;
 using Moq;
 using Tharga.Console.Commands;
-using Tharga.Console.Entities;
 using Xunit;
 
 namespace Tharga.Console.Tests

--- a/Tharga.Console/Tharga.Console.csproj
+++ b/Tharga.Console/Tharga.Console.csproj
@@ -12,6 +12,16 @@
 		<PackageProjectUrl>https://github.com/Tharga/Console</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<DebugType>portable</DebugType>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSource>true</IncludeSource>
+		<IncludeSymbols>true</IncludeSymbols>
+		<!-- snupkg, not the legacy .symbols.nupkg: that name still ends in .nupkg,
+		     so the release push loop would upload it as a regular package and
+		     nuget.org would reject it as a duplicate. -->
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
General cleanup of the Console repo.

### Packaging
- **Declared the licence.** The repo has an MIT LICENSE file but none of the three packages ever said so — every push logged `License missing`.
- **Added symbol support.** Console was one of the few shipping repos with no `IncludeSymbols` at all, so consumers could never step into the source. Uses `snupkg`, not the legacy `.symbols.nupkg` — that name still ends in `.nupkg`, so the push loop would upload it as a regular package and nuget.org would reject it as a duplicate, which is how symbols failed silently across the rest of the toolkit.
- Removed an unused `System.Text.Json` reference in the sample (NU1510).

### CI
- **A failed push now fails the release.** The loop ended in `|| true`, so nothing a push did could fail the job. `--skip-duplicate` already makes re-pushing an existing version a success, so anything that still fails is real.

### Code
- Removed **20 overrides whose bodies only forwarded to base**, plus the usings they were the last consumers of. The *empty* overrides are deliberately left — those suppress base behaviour and are not redundant.
- Removed a redundant empty constructor.

### .editorconfig
Test classes are named as sentences on purpose (`With_command_line`, `When_writing_a_line`) because the class name is the "given" half of the test description and reads directly in runner output. ReSharper's defaults wanted PascalCase types and `_camelCase` fields, which would destroy that, so `InconsistentNaming` is off under `**/*.Tests/**`.

ReSharper warnings **130 → 89**. 44 tests pass, 2 skipped.